### PR TITLE
0.12 Added RDS ca-cert-identifier, fixed some example issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,40 +7,46 @@ Currently supports
 * RDS (Postgres)
 * S3
 
-
 Branch `0.11` is compatible with `Terraform 0.11`
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | >= 2.37 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| backup\_retention\_period | The backup retention period in days | string | `"7"` | no |
-| create\_rds\_instance | Controls if an RDS instance should be provisioned. | string | `"false"` | no |
-| create\_s3\_bucket | Controls if an S3 bucket should be provisioned | string | `"false"` | no |
-| enable\_datastore | Enables the data store module that will provision data storage resources | string | `"true"` | no |
-| rds\_allocated\_storage | Amount of storage allocated to RDS instance | string | `"10"` | no |
-| rds\_backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | `"16:19-16:49"` | no |
-| rds\_database\_name | Name of the database | string | `""` | no |
-| rds\_engine | The Database engine for the rds instance | string | `"postgres"` | no |
-| rds\_engine\_version | The version of the database engine. | string | `"11.4"` | no |
-| rds\_identifier | Identifier of datastore instance | string | `""` | no |
-| rds\_instance\_class | The instance type to use | string | `"db.t3.small"` | no |
-| rds\_iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `"0"` | no |
-| rds\_monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | string | `"0"` | no |
-| rds\_monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero. | string | `""` | no |
-| rds\_password | RDS database password for the user | string | `""` | no |
-| rds\_security\_group\_ids | A List of security groups to bind to the rds instance | list | `<list>` | no |
-| rds\_skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | string | `"true"` | no |
-| rds\_storage\_encrypted | Specifies whether the DB instance is encrypted | string | `"false"` | no |
-| rds\_storage\_encryption\_kms\_key\_arn | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `""` | no |
-| rds\_subnet\_group | Subnet group for RDS instances | string | `""` | no |
-| rds\_tags | Additional tags for rds datastore resources | map | `<map>` | no |
-| s3\_bucket\_K8s\_worker\_iam\_role\_arn | The arn of the Kubernetes worker role that allows a service to assume the role to access the bucket and options | string | `""` | no |
-| s3\_bucket\_name | The name of the bucket | string | `""` | no |
-| s3\_bucket\_namespace | The namespace of the bucket - intention is to help avoid naming collisions | string | `""` | no |
-| s3\_enable\_versioning | If versioning should be configured on the bucket | string | `"true"` | no |
-| s3\_tags | Additional tags to be added to the s3 resources | map | `<map>` | no |
-| tags | Tags for all datastore resources | map | `<map>` | no |
+|------|-------------|------|---------|:-----:|
+| backup\_retention\_period | The backup retention period in days | `number` | `7` | no |
+| ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
+| create\_rds\_instance | Controls if an RDS instance should be provisioned. | `bool` | `false` | no |
+| create\_s3\_bucket | Controls if an S3 bucket should be provisioned | `bool` | `false` | no |
+| enable\_datastore | Enables the data store module that will provision data storage resources | `bool` | `true` | no |
+| rds\_allocated\_storage | Amount of storage allocated to RDS instance | `number` | `10` | no |
+| rds\_backup\_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | `string` | `"16:19-16:49"` | no |
+| rds\_database\_name | Name of the database | `string` | `""` | no |
+| rds\_engine | The Database engine for the rds instance | `string` | `"postgres"` | no |
+| rds\_engine\_version | The version of the database engine. | `number` | `11.4` | no |
+| rds\_identifier | Identifier of datastore instance | `string` | `""` | no |
+| rds\_instance\_class | The instance type to use | `string` | `"db.t3.small"` | no |
+| rds\_iops | The amount of provisioned IOPS. Setting this implies a storage\_type of 'io1' | `number` | `0` | no |
+| rds\_monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `number` | `0` | no |
+| rds\_monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring\_interval is non-zero. | `string` | `""` | no |
+| rds\_password | RDS database password for the user | `string` | `""` | no |
+| rds\_security\_group\_ids | A List of security groups to bind to the rds instance | `list(string)` | `[]` | no |
+| rds\_skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final\_snapshot\_identifier | `bool` | `true` | no |
+| rds\_storage\_encrypted | Specifies whether the DB instance is encrypted | `bool` | `false` | no |
+| rds\_storage\_encryption\_kms\_key\_arn | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage\_encrypted is set to true and kms\_key\_id is not specified the default KMS key created in your account will be used | `string` | `""` | no |
+| rds\_subnet\_group | Subnet group for RDS instances | `string` | `""` | no |
+| rds\_tags | Additional tags for rds datastore resources | `map` | `{}` | no |
+| s3\_bucket\_K8s\_worker\_iam\_role\_arn | The arn of the Kubernetes worker role that allows a service to assume the role to access the bucket and options | `string` | `""` | no |
+| s3\_bucket\_name | The name of the bucket | `string` | `""` | no |
+| s3\_bucket\_namespace | The namespace of the bucket - intention is to help avoid naming collisions | `string` | `""` | no |
+| s3\_enable\_versioning | If versioning should be configured on the bucket | `bool` | `true` | no |
+| s3\_tags | Additional tags to be added to the s3 resources | `map` | `{}` | no |
+| tags | Tags for all datastore resources | `map` | `{}` | no |
 
 ## Outputs
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+# Examples
+Examples of how to use this module.
+
+* [No Datasource](./no_datastore) - Configured to use the module, but not create any resources
+* [RDS](./rds) - Configured to create a PostgreSQL instance using the module
+* [S3](./s3) - Configured to create an S3 bucket
+
+# Running the Examples
+The examples are configured to be run in the `ap-southeast-2` AWS region. To
+change this when running an example you will need to update the `my_region`
+variable in the `vars.tf` file.
+
+### vars.tf
+```
+variable "my_region" {
+  description = "AWS region where example resources will be created"
+  default     = "ap-southeast-2"
+}
+```

--- a/examples/no_datastore/main.tf
+++ b/examples/no_datastore/main.tf
@@ -9,10 +9,6 @@ module "example_no_datastore" {
   create_rds_instance = false
 }
 
-provider "aws" {
-  region = "ap-southeast-2"
-}
-
 output "endpoint" {
   value = module.example_no_datastore.rds_instance_endpoint
 }

--- a/examples/no_datastore/providers.tf
+++ b/examples/no_datastore/providers.tf
@@ -1,0 +1,5 @@
+# Default Configuration Provider
+provider "aws" {
+  region = var.my_region
+}
+

--- a/examples/no_datastore/vars.tf
+++ b/examples/no_datastore/vars.tf
@@ -1,0 +1,4 @@
+variable "my_region" {
+  description = "AWS region where example resources will be created"
+  default     = "ap-southeast-2"
+}

--- a/examples/no_datastore/versions.tf
+++ b/examples/no_datastore/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/examples/rds/main.tf
+++ b/examples/rds/main.tf
@@ -51,10 +51,6 @@ module "example_datastore_rds" {
   rds_password = "reallylongpassword"
 }
 
-provider "aws" {
-  region = var.aws_region
-}
-
 variable "aws_region" {
   default = "ap-southeast-2"
 }

--- a/examples/rds/providers.tf
+++ b/examples/rds/providers.tf
@@ -1,0 +1,5 @@
+# Default Configuration Provider
+provider "aws" {
+  region = var.my_region
+}
+

--- a/examples/rds/vars.tf
+++ b/examples/rds/vars.tf
@@ -1,0 +1,4 @@
+variable "my_region" {
+  description = "AWS region where example resources will be created"
+  default     = "ap-southeast-2"
+}

--- a/examples/rds/versions.tf
+++ b/examples/rds/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/examples/s3/main.tf
+++ b/examples/s3/main.tf
@@ -1,20 +1,16 @@
 module "example_s3_datastore" {
   source = "../../"
 
-  providers {
-    aws = "aws"
+  providers = {
+    aws = aws
   }
 
   enable_datastore    = true
   create_s3_bucket    = true
-  name                = "s3-datastore"
+  s3_bucket_name      = "s3-datastore"
   s3_bucket_namespace = "stage.example.com"
 
   s3_bucket_K8s_worker_iam_role_arn = "arn:aws:iam::0123456789:role/eks-worker-role"
-}
-
-provider "aws" {
-  region = "ap-southeast-2"
 }
 
 output "bucket_name" {

--- a/examples/s3/providers.tf
+++ b/examples/s3/providers.tf
@@ -1,0 +1,5 @@
+# Default Configuration Provider
+provider "aws" {
+  region = var.my_region
+}
+

--- a/examples/s3/vars.tf
+++ b/examples/s3/vars.tf
@@ -1,0 +1,4 @@
+variable "my_region" {
+  description = "AWS region where example resources will be created"
+  default     = "ap-southeast-2"
+}

--- a/rds.tf
+++ b/rds.tf
@@ -12,6 +12,7 @@ resource "aws_db_instance" "this" {
 
   db_subnet_group_name    = var.rds_subnet_group
   vpc_security_group_ids  = var.rds_security_group_ids
+  ca_cert_identifier      = var.ca_cert_identifier
   allocated_storage       = var.rds_allocated_storage
   backup_retention_period = var.backup_retention_period
   iops                    = var.rds_iops

--- a/vars.tf
+++ b/vars.tf
@@ -44,6 +44,11 @@ variable "rds_security_group_ids" {
   default     = []
 }
 
+variable "ca_cert_identifier" {
+  description = "Specifies the identifier of the CA certificate for the DB instance"
+  default     = "rds-ca-2019"
+}
+
 variable "rds_allocated_storage" {
   description = "Amount of storage allocated to RDS instance"
   default     = 10

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = "~> 2.19"
+    aws = ">= 2.37"
   }
 
 }


### PR DESCRIPTION
Added the ca_cert_identifier to the rds resource. Added variable with a default value and regenerated the documentation.

The S3 example was not working so fixed the issue with this.

Reworked the examples - with some documentation about the providers and their use. I feel using the default provider is enough in each, but I know there is a reason you have multiple providers so was unsure if they should all meet that or not!

_NB_ reworked terraform-docs by using a version that supports 0.12.  Uses terraform-docs 0.8.1