### PR TITLE
Apply new IAM pattern for Data Storage resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Branch `0.11` is compatible with `Terraform 0.11`
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
+| rds\_option\_group\_name | Name of the DB option group to associate | `string` | n/a | yes |
 | backup\_retention\_period | The backup retention period in days | `number` | `7` | no |
 | create\_rds\_instance | Controls if an RDS instance should be provisioned. | `bool` | `false` | no |
 | create\_s3\_bucket | Controls if an S3 bucket should be provisioned | `bool` | `false` | no |
@@ -43,13 +44,12 @@ Branch `0.11` is compatible with `Terraform 0.11`
 | rds\_subnet\_group | Subnet group for RDS instances | `string` | `""` | no |
 | rds\_tags | Additional tags for rds datastore resources | `map` | `{}` | no |
 | rds\_username | RDS database user name | `string` | `""` | no |
-| s3\_bucket\_K8s\_worker\_iam\_role\_arn | The arn of the Kubernetes worker role that allows a service to assume the role to access the bucket and options | `string` | `""` | no |
 | s3\_bucket\_name | The name of the bucket | `string` | `""` | no |
 | s3\_bucket\_namespace | The namespace of the bucket - intention is to help avoid naming collisions | `string` | `""` | no |
 | s3\_enable\_versioning | If versioning should be configured on the bucket | `bool` | `true` | no |
 | s3\_tags | Additional tags to be added to the s3 resources | `map` | `{}` | no |
 | tags | Tags for all datastore resources | `map` | `{}` | no |
-| use_rds_snapshot | Controls if an RDS snapshot should be used. | `bool` | `false` | no |
+| use\_rds\_snapshot | Controls if an RDS snapshot should be used. | `bool` | `false` | no |
 
 ## Outputs
 
@@ -63,5 +63,5 @@ Branch `0.11` is compatible with `Terraform 0.11`
 | rds\_instance\_endpoint | The connection endpoint |
 | rds\_instance\_id | The RDS instance ID |
 | s3\_bucket | The name of the bucket |
-| s3\_bucket\_role\_name | The name of the IAM role with access policy |
+| s3\_bucket\_policy\_arn | Policy arn to be attached to a execution role defined in the parent module |
 

--- a/examples/s3/main.tf
+++ b/examples/s3/main.tf
@@ -1,16 +1,14 @@
 module "example_s3_datastore" {
   source = "../../"
 
-  providers {
-    aws = "aws"
+  providers = {
+    aws = aws
   }
 
   enable_datastore    = true
   create_s3_bucket    = true
-  name                = "s3-datastore"
+  s3_bucket_name      = "s3-datastore"
   s3_bucket_namespace = "stage.example.com"
-
-  s3_bucket_K8s_worker_iam_role_arn = "arn:aws:iam::0123456789:role/eks-worker-role"
 }
 
 provider "aws" {
@@ -21,6 +19,6 @@ output "bucket_name" {
   value = "${module.example_s3_datastore.s3_bucket}"
 }
 
-output "bucket_role_name" {
-  value = "${module.example_s3_datastore.s3_bucket_role_name}"
+output "bucket_policy_arn" {
+  value = "${module.example_s3_datastore.s3_bucket_policy_arn}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,8 +45,8 @@ output "s3_bucket" {
   value       = join(",", aws_s3_bucket.this.*.bucket)
 }
 
-output "s3_bucket_role_name" {
-  description = "The name of the IAM role with access policy"
-  value       = join(",", aws_iam_role.s3_datastore_bucket.*.name)
+output "s3_bucket_policy_arn" {
+  description = "Policy arn to be attached to a execution role defined in the parent module"
+  value       = join(",", aws_iam_policy.s3_datastore_bucket[*].arn)
 }
 

--- a/s3_iam.tf
+++ b/s3_iam.tf
@@ -54,39 +54,7 @@ data "aws_iam_policy_document" "s3_datastore_bucket" {
 resource "aws_iam_policy" "s3_datastore_bucket" {
   count = local.create_s3
 
-  name        = "S3BucketObjectAccess${replace(title(var.s3_bucket_name), "/-| /", "")}Policy"
+  name        = "S3DatstoreBucketObjectAccess${replace(title(var.s3_bucket_name), "/-| /", "")}Policy"
   policy      = data.aws_iam_policy_document.s3_datastore_bucket[0].json
-  description = "Grants permissions to access the bucket and associated objects in S3 bucket"
+  description = "Grants permissions to access the datastore bucket and associated objects"
 }
-
-resource "aws_iam_role_policy_attachment" "s3_datastore_bucket" {
-  count = local.create_s3
-
-  role       = aws_iam_role.s3_datastore_bucket[0].name
-  policy_arn = aws_iam_policy.s3_datastore_bucket[0].arn
-}
-
-resource "aws_iam_role" "s3_datastore_bucket" {
-  count = local.create_s3
-
-  name        = "k8s-S3BucketAccess${replace(title(var.s3_bucket_name), "/-| /", "")}Role"
-  description = "Role Assumption policy for S3 bucket access"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "AWS": "${var.s3_bucket_K8s_worker_iam_role_arn}"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-
-}
-

--- a/vars.tf
+++ b/vars.tf
@@ -146,11 +146,6 @@ variable "s3_enable_versioning" {
   default     = true
 }
 
-variable "s3_bucket_K8s_worker_iam_role_arn" {
-  description = "The arn of the Kubernetes worker role that allows a service to assume the role to access the bucket and options"
-  default     = ""
-}
-
 variable "s3_tags" {
   description = "Additional tags to be added to the s3 resources"
   default     = {}


### PR DESCRIPTION
Previously this module would create a specific role for any data storage resource and bind a policy to it. This is now considered to be the scope of the parent module. This module only creates policies that then can be attached by the parent module.

This provides a better abstraction to implement an Execution Role pattern

The s3 object was the only resource that used an IAM policy. The module now outputs the `s3_bucket_policy_arn` which can be used to attach the policy with a role