### PR TITLE
Allow IAM access to dynanamodb subresources

### DIFF
--- a/dynamodb_iam.tf
+++ b/dynamodb_iam.tf
@@ -17,7 +17,8 @@ data "aws_iam_policy_document" "dynamodb_table_datastore" {
     ]
 
     resources = [
-      join("", aws_dynamodb_table.this[*].arn)
+      join("", aws_dynamodb_table.this[*].arn),
+      "${join("", aws_dynamodb_table.this[*].arn)}/*"
     ]
   }
 


### PR DESCRIPTION
While the terraform module theoretically supports adding GSIs (and LSIs), permission to access these GSIs is not granted.
This is because GSIs require ARN access as `<table arn>/<gsi name>`, but the resource granted is only `<table arn>`.

This PR adds access to all subresources of a table. Alternatively it could be possible to read the GSI names and only add `<arn>/<gsi name>` for each but I don't know the terraform for this 😆. Access to all subresources for a table shouldnt be a problem.